### PR TITLE
Prod Fixes 1

### DIFF
--- a/apps/spa-3ncount3r/src/components/dialog-handlers/save-handler/save-handler.tsx
+++ b/apps/spa-3ncount3r/src/components/dialog-handlers/save-handler/save-handler.tsx
@@ -23,7 +23,7 @@ export const SaveHandler : React.FC = () => {
                 await saveEncounterTemplate(encounterName, encounterContext.creatures);
             } else {
                 await saveEncounter(encounterName, encounterContext.creatures, 
-                    encounterContext.selectedParty, encounterContext.roundCounter, encounterContext.turnCounter);
+                    encounterContext.selectedParty, Math.max(encounterContext.roundCounter, 1), Math.max(encounterContext.turnCounter, 1));
             }
 
             if (encounterId !== '') {

--- a/apps/spa-3ncount3r/src/components/modals/initiative/initiative.modal.tsx
+++ b/apps/spa-3ncount3r/src/components/modals/initiative/initiative.modal.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useState } from "react";
-import { Box, Grid, Typography, Button, Table, TableHead, TableRow, TableCell, TableBody, TextField, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Checkbox } from "@mui/material";
+import { Box, Grid, Typography, Button, Table, TableHead, TableRow, TableCell, TableBody, TextField, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Checkbox, TableContainer } from "@mui/material";
 
 import { EncounterCreatureViewModel } from "../../../view-models/encounter-creature.view-model";
 import { doDiceFormulaCalculation } from "../../../services/dice.service";
@@ -90,46 +90,48 @@ export const InitiativeModal : React.FC<InitiativeModalProps> = forwardRef(({ cr
                         </FormControl>
                     </Grid>
                     <Grid xs={12}>
-                        <Table>
-                            <TableHead>
-                                <TableRow>
-                                    <TableCell>Active</TableCell>
-                                    <TableCell>Creature</TableCell>
-                                    <TableCell>Modifier</TableCell>
-                                    <TableCell>Rolled</TableCell>
-                                    <TableCell>Initiative</TableCell>
-                                    <TableCell>Actions</TableCell>
-                                </TableRow>
-                            </TableHead>
-                            <TableBody>
-                                {creatures.map((creature, index) => (
-                                    <TableRow key={`creature_${index}`}>
-                                        <TableCell>
-                                            <Checkbox checked={creature.isActive} onChange={(e, checked) => toggleIsActive(index, checked)} />
-                                        </TableCell>
-                                        <TableCell>{creature.name}</TableCell>
-                                        <TableCell>{calculateAbilityScoreModifier(creature.attributeDex)}</TableCell>
-                                        <TableCell>
-                                            <TextField
-                                                type="number"
-                                                variant="standard"
-                                                value={creature.initiative - calculateAbilityScoreModifier(creature.attributeDex)}
-                                                onChange={(e) => { manuallyUpdateRolledInitiative(e, index) }} disabled={!creature.isActive} />
-                                        </TableCell>
-                                        <TableCell>
-                                            <TextField
-                                                type="number"
-                                                variant="standard"
-                                                value={creature.initiative}
-                                                onChange={(e) => { manuallyUpdateInitiative(e, index) }} disabled={!creature.isActive} />                                            
-                                        </TableCell>
-                                        <TableCell>
-                                            <Button variant="outlined" onClick={() => rollInitiativeForCreature(index)} disabled={!creature.isActive}>Roll</Button>
-                                        </TableCell>
+                        <TableContainer sx={{ maxHeight: "70vh"}}>
+                            <Table stickyHeader>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell>Active</TableCell>
+                                        <TableCell>Creature</TableCell>
+                                        <TableCell>Modifier</TableCell>
+                                        <TableCell>Rolled</TableCell>
+                                        <TableCell>Initiative</TableCell>
+                                        <TableCell>Actions</TableCell>
                                     </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
+                                </TableHead>
+                                <TableBody>
+                                    {creatures.map((creature, index) => (
+                                        <TableRow key={`creature_${index}`}>
+                                            <TableCell>
+                                                <Checkbox checked={creature.isActive} onChange={(e, checked) => toggleIsActive(index, checked)} />
+                                            </TableCell>
+                                            <TableCell>{creature.name}</TableCell>
+                                            <TableCell>{calculateAbilityScoreModifier(creature.attributeDex)}</TableCell>
+                                            <TableCell>
+                                                <TextField
+                                                    type="number"
+                                                    variant="standard"
+                                                    value={creature.initiative - calculateAbilityScoreModifier(creature.attributeDex)}
+                                                    onChange={(e) => { manuallyUpdateRolledInitiative(e, index) }} disabled={!creature.isActive} />
+                                            </TableCell>
+                                            <TableCell>
+                                                <TextField
+                                                    type="number"
+                                                    variant="standard"
+                                                    value={creature.initiative}
+                                                    onChange={(e) => { manuallyUpdateInitiative(e, index) }} disabled={!creature.isActive} />                                            
+                                            </TableCell>
+                                            <TableCell>
+                                                <Button variant="outlined" onClick={() => rollInitiativeForCreature(index)} disabled={!creature.isActive}>Roll</Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
                     </Grid>
                     <Grid xs={12}>
                         <Button variant="outlined" onClick={() => handleAccept(creatures, selectedParty)}>Accept</Button>

--- a/apps/spa-3ncount3r/src/components/modals/initiative/initiative.modal.tsx
+++ b/apps/spa-3ncount3r/src/components/modals/initiative/initiative.modal.tsx
@@ -36,6 +36,12 @@ export const InitiativeModal : React.FC<InitiativeModalProps> = forwardRef(({ cr
         setCreatures(state);
     }
 
+    const manuallyUpdateRolledInitiative = (event: any, index: number) => {
+        let state = [...creatures];
+        state[index].initiative = parseInt(event.target.value) + calculateAbilityScoreModifier(state[index].attributeDex);
+        setCreatures(state);
+    }
+
     const toggleIsActive = (index: number, checked: boolean) => {
         let state = [...creatures];
         state[index].isActive = checked;
@@ -103,7 +109,13 @@ export const InitiativeModal : React.FC<InitiativeModalProps> = forwardRef(({ cr
                                         </TableCell>
                                         <TableCell>{creature.name}</TableCell>
                                         <TableCell>{calculateAbilityScoreModifier(creature.attributeDex)}</TableCell>
-                                        <TableCell>{creature.initiative - calculateAbilityScoreModifier(creature.attributeDex)}</TableCell>
+                                        <TableCell>
+                                            <TextField
+                                                type="number"
+                                                variant="standard"
+                                                value={creature.initiative - calculateAbilityScoreModifier(creature.attributeDex)}
+                                                onChange={(e) => { manuallyUpdateRolledInitiative(e, index) }} disabled={!creature.isActive} />
+                                        </TableCell>
                                         <TableCell>
                                             <TextField
                                                 type="number"

--- a/apps/spa-3ncount3r/src/components/modules/encounterCreatures/encounterCreatures.tsx
+++ b/apps/spa-3ncount3r/src/components/modules/encounterCreatures/encounterCreatures.tsx
@@ -14,6 +14,7 @@ export const EncounterCreatures : React.FC = () => {
     const [open, setOpen] = useState(false);
     const [, setIsTemplate] = useState(false);
     const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+    const [activeCreatures, setActiveCreatures] = useState<EncounterCreatureViewModel[]>([]);
     
     const encounterContext = useEncounterContext();
 
@@ -64,6 +65,7 @@ export const EncounterCreatures : React.FC = () => {
     }, [id]);
 
     useEffect(() => {
+        setActiveCreatures(encounterContext.creatures?.filter(x => x.isActive));
     }, [encounterContext.creatures])
 
     const doHitpointManagement = () => {
@@ -83,9 +85,9 @@ export const EncounterCreatures : React.FC = () => {
     return (
         <>
             <Stack>
-                {encounterContext.creatures?.filter(x => x.isActive).map((creature: EncounterCreatureViewModel, index: number) => (
+                {activeCreatures?.filter(x => x.isActive).map((creature: EncounterCreatureViewModel, index: number) => (
                     <Badge color="secondary" variant='dot' invisible={index === (encounterContext.turnCounter - 1) ? false : true} component={"div"}>
-                        <EncounterCreatureListItem key={creature.id} viewModel={creature} index={index}
+                        <EncounterCreatureListItem key={creature.id} viewModel={creature} index={encounterContext.creatures.indexOf(activeCreatures[index])}
                             handleSelection={handleCreatureSelection} manageHitpoints={doHitpointManagement} isSelected={selectedIndex === index} />
                     </Badge>
                 ))}

--- a/apps/spa-3ncount3r/src/components/modules/encounterCreatures/encounterCreatures.tsx
+++ b/apps/spa-3ncount3r/src/components/modules/encounterCreatures/encounterCreatures.tsx
@@ -9,6 +9,7 @@ import { EncounterCreatureViewModel } from "../../../view-models/encounter-creat
 import { HitpointManagementModal } from "../../modals/hitpoint-management/hitpoint-management.modal";
 
 import { getEncounterById, getEncounterTemplateById } from "../../../services/encounter.service";
+import { EncounterViewModel } from "apps/spa-3ncount3r/src/view-models/encounter.view-model";
 
 export const EncounterCreatures : React.FC = () => {
     const [open, setOpen] = useState(false);
@@ -35,7 +36,7 @@ export const EncounterCreatures : React.FC = () => {
             
             if (segments[segments.length-1] === 'template') {
                 setIsTemplate(true);
-                getEncounterTemplateById(id).then(x => {
+                getEncounterTemplateById(id).then((x: EncounterViewModel) => {
                     encounterContext.setCreatures(x.creatures);
                     encounterContext.setEncounterId(x.id);
                     encounterContext.setEncounterName(x.name);
@@ -44,13 +45,13 @@ export const EncounterCreatures : React.FC = () => {
                     encounterContext.setTurnCounter(0);
                 });
             } else {
-                getEncounterById(id).then(x => {
+                getEncounterById(id).then((x: EncounterViewModel) => {
                     encounterContext.setCreatures(x.creatures);
                     encounterContext.setEncounterId(x.id);
                     encounterContext.setEncounterName(x.name);
                     encounterContext.setSelectedParty(x.selectedParty);
-                    encounterContext.setRoundCounter(x.roundCount);
-                    encounterContext.setTurnCounter(x.currentTurn);
+                    encounterContext.setRoundCounter(Math.max(x.roundCount, 1));
+                    encounterContext.setTurnCounter(Math.max(x.currentTurn, 1));
                 });
             }
         } else {

--- a/apps/spa-3ncount3r/src/components/modules/encounterCreatures/encounterCreatures.tsx
+++ b/apps/spa-3ncount3r/src/components/modules/encounterCreatures/encounterCreatures.tsx
@@ -62,6 +62,8 @@ export const EncounterCreatures : React.FC = () => {
             encounterContext.setRoundCounter(0);
             encounterContext.setTurnCounter(0);
         }
+
+        encounterContext.setSelectedCreatureIndex(encounterContext.creatures ? 1 : 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [id]);
 
@@ -79,17 +81,19 @@ export const EncounterCreatures : React.FC = () => {
     };
 
     const handleCreatureSelection = (index: number) => {
-        setSelectedIndex(index);
-        encounterContext.setSelectedCreatureIndex(index);
+        let contextIndex = encounterContext.creatures.indexOf(activeCreatures[index]);
+        setSelectedIndex(contextIndex);
+        encounterContext.setSelectedCreatureIndex(contextIndex);
     };
 
     return (
         <>
             <Stack>
-                {activeCreatures?.filter(x => x.isActive).map((creature: EncounterCreatureViewModel, index: number) => (
+                {activeCreatures.map((creature: EncounterCreatureViewModel, index: number) => (
                     <Badge color="secondary" variant='dot' invisible={index === (encounterContext.turnCounter - 1) ? false : true} component={"div"}>
-                        <EncounterCreatureListItem key={creature.id} viewModel={creature} index={encounterContext.creatures.indexOf(activeCreatures[index])}
-                            handleSelection={handleCreatureSelection} manageHitpoints={doHitpointManagement} isSelected={selectedIndex === index} />
+                        <EncounterCreatureListItem key={creature.id} viewModel={creature} index={index}
+                            handleSelection={handleCreatureSelection} manageHitpoints={doHitpointManagement} 
+                            isSelected={activeCreatures.indexOf(encounterContext.creatures[selectedIndex]) === index} />
                     </Badge>
                 ))}
             </Stack>
@@ -102,10 +106,12 @@ export const EncounterCreatures : React.FC = () => {
               open={open}
               disablePortal>
                 <DialogContent>
-                    <HitpointManagementModal 
-                        maxHitpoints={selectedIndex > -1 ? encounterContext.creatures[selectedIndex].hitpointMax : 0} 
-                        currentHitpoints={selectedIndex > -1 ? encounterContext.creatures[selectedIndex].currentHitpoints : 0} 
-                        handleAccept={updateHitpoints} handleCancel={() => { setOpen(false); }} />
+                    {selectedIndex > -1 && 
+                        <HitpointManagementModal 
+                            maxHitpoints={encounterContext.creatures[selectedIndex]?.hitpointMax ?? 0} 
+                            currentHitpoints={encounterContext.creatures[selectedIndex]?.currentHitpoints ?? 0} 
+                            handleAccept={updateHitpoints} handleCancel={() => { setOpen(false); }} />
+                    }
                 </DialogContent>
             </Modal>
         </>


### PR DESCRIPTION
Fixed an issue where loading a different encounter would cause an error because of selected index and HP management
Fixed an issue where disabling creatures caused HP management to use the wrong index
Added scrolling to the initiative table on the initiative modal
Added ability to enter the rolled value for initiative
Fixed issue with round and turn counter minimums on started encounters